### PR TITLE
Add Manifest and .dxt file 

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "shell",
+			"label": "Run Clarity MCP Server (ts-node)",
+			"command": "npx ts-node ./src/index.ts",
+			"group": "build",
+			"isBackground": false,
+			"problemMatcher": []
+		}
+	]
+}

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+// This is the CLI entry point for the npx executable
+import './index.js';

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,164 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+// Get configuration from environment variables or command-line arguments
+const getConfigValue = (name, fallback) => {
+    // Check command line args first (format: --name=value)
+    const commandArg = process.argv.find(arg => arg.startsWith(`--${name}=`));
+    if (commandArg) {
+        return commandArg.split('=')[1];
+    }
+    // Check environment variables
+    const envValue = process.env[name.toUpperCase()] || process.env[name];
+    if (envValue) {
+        return envValue;
+    }
+    return fallback;
+};
+// Create server instance
+const server = new McpServer({
+    name: "@microsoft/clarity-mcp-server",
+    version: "1.0.0",
+    capabilities: {
+        resources: {},
+        tools: {},
+    },
+});
+// Constants for API
+const API_BASE_URL = "https://www.clarity.ms/export-data/api/v1/project-live-insights";
+// Available metrics that may be returned by the API
+const AVAILABLE_METRICS = [
+    "ScrollDepth",
+    "EngagementTime",
+    "Traffic",
+    "PopularPages",
+    "Browser",
+    "Device",
+    "OS",
+    "Country/Region",
+    "PageTitle",
+    "ReferrerURL",
+    "DeadClickCount",
+    "ExcessiveScroll",
+    "RageClickCount",
+    "QuickbackClick",
+    "ScriptErrorCount",
+    "ErrorClickCount"
+];
+// Available dimensions that can be used in queries
+const AVAILABLE_DIMENSIONS = [
+    "Browser",
+    "Device",
+    "Country/Region",
+    "OS",
+    "Source",
+    "Medium",
+    "Campaign",
+    "Channel",
+    "URL"
+];
+// Helper function to make API requests
+async function fetchClarityData(token, numOfDays, dimensions = []) {
+    try {
+        // Build parameters for the API request
+        const params = new URLSearchParams();
+        params.append("numOfDays", numOfDays.toString());
+        // Add dimensions if specified (maximum 3 allowed)
+        dimensions.slice(0, 3).forEach((dim, index) => {
+            params.append(`dimension${index + 1}`, dim);
+        });
+        // Make the API request
+        const url = `${API_BASE_URL}?${params.toString()}&src=mcp`;
+        console.error(`Making request to: ${url}`);
+        const response = await fetch(url, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${token}`
+            }
+        });
+        if (!response.ok) {
+            throw new Error(`API request failed with status ${response.status}`);
+        }
+        return await response.json();
+    }
+    catch (error) {
+        console.error("Error fetching Clarity data:", error);
+        return { error: error instanceof Error ? error.message : "Unknown error" };
+    }
+}
+// Register the get-clarity-data tool
+server.tool("get-clarity-data", "Fetch Microsoft Clarity analytics data", {
+    numOfDays: z.number().min(1).max(3).describe("Number of days to retrieve data for (1-3)"),
+    dimensions: z.array(z.string()).optional().describe("Up to 3 dimensions to filter by (Browser, Device, Country/Region, OS, Source, Medium, Campaign, Channel, URL)"),
+    metrics: z.array(z.string()).optional().describe("Metrics to retrieve (Scroll Depth, Engagement Time, Traffic, Popular Pages, Browser, Device, OS, Country/Region, etc.)"),
+    token: z.string().optional().describe("Your Clarity API token (optional if provided via environment or command line)"),
+}, async ({ numOfDays, dimensions = [], metrics = [], token }) => {
+    // Use provided token or fallback to environment/command-line variables
+    // const finalToken = token || CLARITY_API_TOKEN;
+    const finalToken = token || getConfigValue('clarity_api_token') || getConfigValue('CLARITY_API_TOKEN'); // Check if we have the necessary credentials
+    if (!finalToken) {
+        return {
+            content: [
+                {
+                    type: "text",
+                    text: "No Clarity API token provided. Please provide a token via the 'token' parameter, CLARITY_API_TOKEN environment variable, or --clarity_api_token command-line argument.",
+                },
+            ],
+        };
+    }
+    // Validate dimensions against known valid dimensions
+    const filteredDimensions = dimensions.filter(d => AVAILABLE_DIMENSIONS.includes(d));
+    if (filteredDimensions.length < dimensions.length) {
+        console.warn("Some dimensions were invalid and have been filtered out");
+    }
+    // Fetch data from Clarity API
+    const data = await fetchClarityData(finalToken, numOfDays, filteredDimensions);
+    // Check for errors
+    if (data.error) {
+        return {
+            content: [
+                {
+                    type: "text",
+                    text: `Error fetching data: ${data.error}`,
+                },
+            ],
+        };
+    }
+    // Filter metrics if specified
+    let formattedResult = data;
+    if (metrics && metrics.length > 0) {
+        // Filter the metrics if requested (case-insensitive match for user convenience)
+        formattedResult = data.filter((item) => metrics.some(m => item.metricName.toLowerCase() === m.toLowerCase() ||
+            item.metricName.replace(/\s+/g, '').toLowerCase() === m.replace(/\s+/g, '').toLowerCase()));
+    }
+    const resultText = JSON.stringify(formattedResult, null, 2);
+    return {
+        content: [
+            {
+                type: "text",
+                text: resultText,
+            },
+        ],
+    };
+});
+// Main function
+async function main() {
+    // Log configuration status
+    if (getConfigValue('clarity_api_token') || getConfigValue('CLARITY_API_TOKEN')) {
+        console.error("Clarity API token configured via environment/command-line");
+    }
+    else {
+        console.error("No Clarity API token configured, it must be provided with each request");
+    }
+    console.error(`Supported metrics: ${AVAILABLE_METRICS.join(", ")}`);
+    console.error(`Supported dimensions: ${AVAILABLE_DIMENSIONS.join(", ")}`);
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.error("Microsoft Clarity Data Export MCP Server running on stdio");
+}
+// Run the server
+main().catch((error) => {
+    console.error("Fatal error in main():", error);
+    process.exit(1);
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,33 @@
+{
+  "dxt_version": "0.1",
+  "name": "@microsoft/clarity-mcp-server",
+  "version": "1.0.1",
+  "description": "MCP Server to fetch Microsoft Clarity analytics data based on data export API",
+  "long_description": "This extension sets up a server that connects to Microsoft Clarity’s data export API to retrieve analytics data. It allows for real-time and batch data synchronization with external platforms or analytics tools, using a configurable token for authentication. It supports extensibility through command-line arguments and environment configuration.",
+  "author": {
+    "name": "Microsoft"
+  },
+  "server": {
+    "type": "node",
+    "entry_point": "dist/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": [
+        "${__dirname}/dist/index.js"
+      ],
+      "env": {
+     "CLARITY_API_TOKEN": "${user_config.CLARITY_API_TOKEN}"
+      }
+    }
+  },
+  "user_config": {
+    "CLARITY_API_TOKEN": {
+      "type": "string",
+      "title": "API Token",
+      "description": "Provide your API token for Microsoft Clarity",
+      "required": true,
+      "sensitive": true
+    }
+  },
+  "license": "MIT"
+}

--- a/mcp-server.json
+++ b/mcp-server.json
@@ -1,0 +1,16 @@
+{
+  "name": "@microsoft/clarity-mcp-server",
+  "displayName": "Microsoft Clarity MCP Server",
+  "description": "Fetches analytics data from Microsoft Clarity.",
+  "entry": "./src/index.ts",
+  "args": [],
+  "languages": ["*"],
+  "capabilities": {
+    "resources": {},
+    "tools": {
+      "get-clarity-data": {
+        "description": "Fetch Microsoft Clarity analytics data"
+      }
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,8 +26,8 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "Node16",                                  /* Specify what module code is generated. */
-    "moduleResolution": "Node16",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    "module": "NodeNext",                                  /* Specify what module code is generated. */
+    "moduleResolution": "NodeNext",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     "rootDir": "./src",                                  /* Specify the root folder within your source files. */
     "outDir": "./dist",                                  /* Specify an output folder for all emitted files. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
@@ -108,5 +108,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "dist/index.js"]
 }


### PR DESCRIPTION
This pull request adds the necessary configuration to enable Claude AI to connect to the Clarity MCP server and retrieve user-specific Clarity data through a local developer extension setup.

Contributions:
1- Added a valid manifest.json file defining the extension's metadata and permissions
2- Implemented the dxt.json packaging configuration
3- Ensured that Claude AI connects successfully to the MCP server and accesses Clarity account data for the authenticated user
<img width="600" height="500" alt="image" src="https://github.com/user-attachments/assets/03bb48e5-d610-4a38-a230-3208a4ce381e" />

Results:
1- Claude AI can now interact with the MCP server and retrieve relevant Clarity analytics.
2- The setup functions through DXT as a developer extension



