### PR TITLE
Support VS Code default install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/clarity-mcp-server",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "MCP Server for Microsoft Clarity based on data export API",
   "author": "Microsoft",
   "license": "MIT",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,16 +3,19 @@ import { CLARITY_API_TOKEN } from "./constants.js";
 // Get configuration from environment variables or command-line arguments
 export const getConfigValue = (name: string, fallback?: string): string | undefined => {
   // Check command line args first (format: --name=value or --name value)
-  const argIndex = process.argv.findIndex((arg) => arg === `--${name}` || arg.startsWith(`--${name}=`));
+  const argIndex = process.argv.findIndex((arg) => arg.startsWith(`--${name}`));
   if (argIndex !== -1) {
     const arg = process.argv[argIndex];
     if (arg.includes("=")) {
       return arg.split("=")[1];
     }
     // --name value format: return next argument if it exists and isn't another flag
-    const nextArg = process.argv[argIndex + 1];
-    if (nextArg && !nextArg.startsWith("--")) {
-      return nextArg;
+    const nextArgIndex = argIndex + 1;
+    if (nextArgIndex < process.argv.length) {
+      const nextArg = process.argv[nextArgIndex];
+      if (nextArg && !nextArg.startsWith("--")) {
+        return nextArg;
+      }
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,10 +2,18 @@ import { CLARITY_API_TOKEN } from "./constants.js";
 
 // Get configuration from environment variables or command-line arguments
 export const getConfigValue = (name: string, fallback?: string): string | undefined => {
-  // Check command line args first (format: --name=value)
-  const commandArg = process.argv.find(arg => arg.startsWith(`--${name}=`));
-  if (commandArg) {
-    return commandArg.split('=')[1];
+  // Check command line args first (format: --name=value or --name value)
+  const argIndex = process.argv.findIndex((arg) => arg === `--${name}` || arg.startsWith(`--${name}=`));
+  if (argIndex !== -1) {
+    const arg = process.argv[argIndex];
+    if (arg.includes("=")) {
+      return arg.split("=")[1];
+    }
+    // --name value format: return next argument if it exists and isn't another flag
+    const nextArg = process.argv[argIndex + 1];
+    if (nextArg && !nextArg.startsWith("--")) {
+      return nextArg;
+    }
   }
 
   // Then check environment variables


### PR DESCRIPTION
This PR updates the server so that it parses command line arguments in either `--name=value` or `--name value` format.

This is needed to add support so that the MCP server install through VS Code works by default. When the MCP server is installed through the VS Code extension library, the Clarity API token is passed to the command line as separate arguments (`--clarity_api_token xyz` format):

<img width="3122" height="1874" alt="image" src="https://github.com/user-attachments/assets/02ae6caa-9c31-4b22-a8de-e8f77e87e054" />

Unless the user manually modifies their MCP config to use `--name=value` format (not intuitive, took me a while to figure it out!), they receive the following error on MCP server startup:

```
[warning] [server stderr] No Clarity API token configured, it must be provided with each request
```
