### PR TITLE
feat: Multi-account support — query multiple Clarity projects by domain name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,178 +1,89 @@
-# Microsoft Clarity MCP Server
+# Clarity MCP Server (Multi-Account)
 
-This is a Model Context Protocol (MCP) server for the Microsoft Clarity.
-It allows you to access your session recordings, project analytics, and documentation from Clarity using Claude for Desktop or other MCP-compatible clients.
+A [Model Context Protocol](https://modelcontextprotocol.io) server for Microsoft Clarity that supports **multiple projects** — identified by domain name.
 
-## Key Features
+Fork of [@microsoft/clarity-mcp-server](https://github.com/microsoft/clarity-mcp-server) with multi-account support.
 
-- **Analytics Data Access**: Query your Microsoft Clarity analytics data including traffic metrics, user behavior insights, and performance statistics
-- **Session Recording Retrieval**: Access and analyze session recordings to understand user interactions and identify optimization opportunities
-- **Natural Language Querying**: Ask questions in plain English to get insights from your data - no need to learn complex query syntax or API endpoints
-- **Flexible Data Filtering**: Filter results by various dimensions such as browser, device, country, and many more
-- **Real-Time Data Access**: Fetch the latest analytics data and insights from your Clarity projects on-demand
-- **Documentation Integration**: Get quick answers and guidance from Microsoft Clarity documentation directly within your workflow
-- **Seamless MCP Integration**: Works natively with Claude for Desktop, Visual Studio Code, and other Model Context Protocol (MCP) compatible clients
+## Why?
 
-## Setup and Installation
+The official server supports one API token at a time. If you manage multiple sites with Clarity, you'd need to run separate server instances. This fork lets you configure all your projects in one place and query any of them by domain name.
 
-### Prerequisites
+## Setup
 
-- Node.js v16 or higher
-- A Microsoft Clarity account and API token
-- Any MCP-compatible client (Claude for Desktop, etc.)
-
-### Installation
-
-#### Option 1: Install via npm (recommended)
-
-You can install and run this package directly using npm:
+### 1. Create accounts config
 
 ```bash
-# Install globally
-npm install -g @microsoft/clarity-mcp-server
-
-# Run the server
-clarity-mcp-server
+mkdir -p ~/.clarity-mcp
 ```
 
-#### Option 2: Run with npx without installing
-
-You can run the server directly using npx without installing:
-
-```bash
-npx @microsoft/clarity-mcp-server
+```json
+// ~/.clarity-mcp/accounts.json
+{
+  "default": "mysite.com",
+  "accounts": {
+    "mysite.com": { "token": "your-clarity-api-token-1" },
+    "clientsite.com": { "token": "your-clarity-api-token-2" },
+    "blog.example.org": { "token": "your-clarity-api-token-3" }
+  }
+}
 ```
 
-With either option, you can provide your Clarity API token using the `--clarity_api_token` parameter:
+### 2. Get your API tokens
 
-```bash
-npx @microsoft/clarity-mcp-server --clarity_api_token=your-token-here
-```
+Each Clarity project has its own API token. Get them from the [Clarity Data Export API](https://learn.microsoft.com/en-us/clarity/setup-and-installation/clarity-data-export-api).
 
-#### Option 3: Manual Installation
-
-1. Clone or download this repository
-2. Install dependencies:
-   ```
-   npm install
-   ```
-3. Build the TypeScript code:
-   ```
-   npm run build
-   ```
-4. Run the server:
-   ```
-   npm run start
-   ```
-
-### Extension/Plugin Installation
-
-#### Visual Studio Code Extension
-
-[<img src="https://img.shields.io/badge/VS_Code-VS_Code?style=flat-square&label=Install+Server&color=0098FF" alt="Install in VS Code">](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%257B%2522name%2522%253A%2522clarity-server%2522%252C%2522command%2522%253A%2522npx%2522%252C%2522args%2522%253A%255B%2522%2540microsoft%252Fclarity-mcp-server%2522%255D%257D)
-
-Click the button above to install the Microsoft Clarity MCP server directly in Visual Studio Code.
-
-#### Claude Desktop Plugin
-
-Install from Claude's extension gallery:
-
-1. Open **Claude Desktop**
-2. Navigate to **File → Settings → Extensions**
-3. Search for **Microsoft Clarity**
-4. Click **Install** to add the extension
-5. Configure your **API Token**:
-   <br>
-   Follow the instructions in the [API Token section](#api-token) to retrieve and set it up correctly.
-
-## Configuration
-
-You can provide the [Clarity data export API](https://learn.microsoft.com/en-us/clarity/setup-and-installation/clarity-data-export-api) token in two ways:
-
-1. **Command Line Arguments**:
-   ```bash
-   npx @microsoft/clarity-mcp-server --clarity_api_token=your-token
-   ```
-
-2. **Tool Parameters**:
-   <br>
-   Provide `token` as a parameter when calling the `get-clarity-data` tool
-
-## Configuring MCP Clients
-
-### Generic MCP Client Configuration
-
-MCP clients typically require configuration to connect to the server. Here's a general example of how to configure an MCP client:
+### 3. Configure your MCP client
 
 ```json
 {
   "mcpServers": {
-    "@microsoft/clarity-mcp-server": {
-      "command": "npx",
-      "args": [
-        "@microsoft/clarity-mcp-server",
-        "--clarity_api_token=your-api-token-here"
-      ]
+    "clarity": {
+      "command": "node",
+      "args": ["/path/to/clarity-mcp-server-multi/dist/index.js"]
     }
   }
 }
 ```
 
-The specifics of where and how to add this configuration will depend on your specific MCP client.
+## Usage
 
-### Claude for Desktop Configuration
+### List accounts
+Ask: *"What Clarity accounts are available?"*
 
-To configure Claude for Desktop to use this server:
+### Query a specific site
+Ask: *"Show me session recordings for clientsite.com from the last 3 days"*
 
-1. Open your Claude for Desktop configuration file:
-   - **Windows**: `%AppData%\Claude\claude_desktop_config.json`
-   - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-2. Add the configuration shown in the generic example above
-3. Save the configuration file and restart Claude for Desktop
+### Query the default
+Ask: *"How many sessions did we get last week?"* (uses default account)
 
-## Server Usage
+## Tools
 
-The server exposes various tools that you can call from any MCP client.
-Just ask naturally and keep each request focused on one thing.
+| Tool | Description |
+|------|-------------|
+| `list-clarity-accounts` | List all configured accounts and the default |
+| `query-analytics-dashboard` | Natural language analytics queries |
+| `list-session-recordings` | Session recordings with filters |
+| `query-documentation-resources` | Clarity docs search |
 
-### Query Analytics Dashboard
-- <b>Name:</b> `query-analytics-dashboard`
-- <b>Description:</b> Retrieves analytics data and metrics from your project's dashboard using a simplified natural language search query.
-- <b>Examples:</b>
-  - How many Clarity sessions did we get from Egypt in the past 3 days?
-  - What are the most used browsers in my Clarity project?
-  - Show me traffic metrics from my Clarity project for the last week
+All data tools accept an optional `account` parameter (domain name).
 
-### List Session Recordings
-- <b>Name:</b> `list-session-recordings`
-- <b>Description:</b> Lists your project's session recordings based on a specified filtering criteria. The filters allow you to narrow down the recordings by various fields such as URLs, device types, browser, OS, country, city, and more.
-- <b>Examples:</b>
-  - List the most recent Clarity sessions from mobile devices
-  - Show the top 5 Clarity sessions with the highest number of user clicks
-  - Get Clarity recordings where users encountered JavaScript errors
+## Backward Compatible
 
-### Query Documentation Resources
-- <b>Name:</b> `query-documentation-resources`
-- <b>Description:</b> Retrieves snippets from Microsoft Clarity documentation to find answers to user questions including step-by-step screenshots for setup guides, features, usage, troubleshooting, and integration instructions.
-- <b>Examples:</b>
-  - How to track custom events using Microsoft Clarity?
-  - How many labels can I add to a recording in Microsoft Clarity?
+Still works with a single token via CLI arg or env var:
 
-## API Token
+```bash
+node dist/index.js --clarity_api_token=your-token
+# or
+CLARITY_API_TOKEN=your-token node dist/index.js
+```
 
-### Getting Your API Token
+## Config file locations
 
-To generate an API token:
-
-1. Go to your Clarity project
-2. Select Settings → Data Export → Generate new API token
-3. Provide a descriptive name for the token
-4. Save the generated token securely
-
-## Privacy Policy
-
-For information about data privacy and usage, please refer to the [Microsoft Clarity Privacy Policy](https://clarity.microsoft.com/privacy).
+Checked in order:
+1. `--accounts-file=/custom/path.json`
+2. `~/.clarity-mcp/accounts.json`
+3. `~/.config/clarity-mcp/accounts.json`
 
 ## License
 
-This project is licensed under the <b>MIT</b> License.
+MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1178 @@
+{
+  "name": "clarity-mcp-server-multi",
+  "version": "3.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "clarity-mcp-server-multi",
+      "version": "3.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.20.2",
+        "zod": "^3.25.76"
+      },
+      "bin": {
+        "clarity-mcp-server": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.19.23",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "@microsoft/clarity-mcp-server",
-  "version": "2.0.2",
-  "description": "MCP Server for Microsoft Clarity based on data export API",
-  "author": "Microsoft",
+  "name": "clarity-mcp-server-multi",
+  "version": "3.0.0",
+  "description": "Multi-account MCP Server for Microsoft Clarity - query multiple projects by domain name",
+  "author": "Zen Media Social (fork of Microsoft clarity-mcp-server)",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
-  "homepage": "https://clarity.microsoft.com/",
+  "homepage": "https://github.com/zenmediasocial/clarity-mcp-server-multi",
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoft/clarity-mcp-server"
+    "url": "https://github.com/zenmediasocial/clarity-mcp-server-multi"
   },
   "keywords": [
     "clarity",
@@ -21,7 +21,9 @@
     "mcp",
     "model-context-protocol",
     "ai",
-    "agents"
+    "agents",
+    "multi-account",
+    "multi-project"
   ],
   "bin": {
     "clarity-mcp-server": "./dist/cli.js"

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -1,0 +1,149 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { getConfigValue } from "./utils.js";
+
+export interface AccountEntry {
+  token: string;
+}
+
+export interface AccountsConfig {
+  default?: string;
+  accounts: Record<string, AccountEntry>;
+}
+
+const CONFIG_PATHS = [
+  path.join(os.homedir(), ".clarity-mcp", "accounts.json"),
+  path.join(os.homedir(), ".config", "clarity-mcp", "accounts.json"),
+];
+
+let _cached: AccountsConfig | null = null;
+
+/**
+ * Load accounts from config file, CLI args, or env vars.
+ * Priority:
+ *   1. --accounts-file=/path/to/accounts.json
+ *   2. ~/.clarity-mcp/accounts.json or ~/.config/clarity-mcp/accounts.json
+ *   3. Single token via --clarity_api_token or CLARITY_API_TOKEN (legacy compat)
+ */
+export function loadAccounts(): AccountsConfig {
+  if (_cached) return _cached;
+
+  // Check for explicit accounts file path
+  const explicitPath = getConfigValue("accounts_file") || getConfigValue("accounts-file");
+  if (explicitPath && fs.existsSync(explicitPath)) {
+    _cached = parseAccountsFile(explicitPath);
+    return _cached;
+  }
+
+  // Check default config paths
+  for (const configPath of CONFIG_PATHS) {
+    if (fs.existsSync(configPath)) {
+      _cached = parseAccountsFile(configPath);
+      return _cached;
+    }
+  }
+
+  // Fallback: single token from CLI/env (backward compatible)
+  const singleToken = getConfigValue("clarity_api_token");
+  if (singleToken) {
+    _cached = {
+      default: "default",
+      accounts: {
+        default: { token: singleToken },
+      },
+    };
+    return _cached;
+  }
+
+  // No config at all
+  _cached = { accounts: {} };
+  return _cached;
+}
+
+function parseAccountsFile(filePath: string): AccountsConfig {
+  try {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(raw);
+
+    if (!parsed.accounts || typeof parsed.accounts !== "object") {
+      console.error(`Invalid accounts config: missing "accounts" object in ${filePath}`);
+      return { accounts: {} };
+    }
+
+    // Validate each entry has a token
+    const accounts: Record<string, AccountEntry> = {};
+    for (const [domain, entry] of Object.entries(parsed.accounts)) {
+      const e = entry as any;
+      if (typeof e?.token === "string" && e.token.length > 0) {
+        accounts[domain] = { token: e.token };
+      } else {
+        console.error(`Skipping account "${domain}": missing or empty token`);
+      }
+    }
+
+    return {
+      default: parsed.default || undefined,
+      accounts,
+    };
+  } catch (err) {
+    console.error(`Failed to parse accounts config at ${filePath}:`, err);
+    return { accounts: {} };
+  }
+}
+
+/**
+ * Resolve the API token for a given account identifier (domain).
+ * Falls back to default account if no account specified.
+ */
+export function resolveToken(account?: string): { token: string; account: string } | null {
+  const config = loadAccounts();
+  const domains = Object.keys(config.accounts);
+
+  if (domains.length === 0) return null;
+
+  // If account specified, look it up directly
+  if (account) {
+    const entry = config.accounts[account];
+    if (entry) return { token: entry.token, account };
+
+    // Try case-insensitive match
+    const lower = account.toLowerCase();
+    for (const [domain, entry] of Object.entries(config.accounts)) {
+      if (domain.toLowerCase() === lower) {
+        return { token: entry.token, account: domain };
+      }
+    }
+
+    return null; // Not found
+  }
+
+  // No account specified — use default
+  if (config.default && config.accounts[config.default]) {
+    return { token: config.accounts[config.default]!.token, account: config.default };
+  }
+
+  // If only one account, use it
+  if (domains.length === 1) {
+    const domain = domains[0]!;
+    return { token: config.accounts[domain]!.token, account: domain };
+  }
+
+  // Multiple accounts, no default set, no account specified
+  return null;
+}
+
+/**
+ * List all configured account domains.
+ */
+export function listAccounts(): string[] {
+  const config = loadAccounts();
+  return Object.keys(config.accounts);
+}
+
+/**
+ * Get the default account domain, if set.
+ */
+export function getDefaultAccount(): string | undefined {
+  return loadAccounts().default;
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,3 @@
-import { getConfigValue } from "./utils.js";
-
-export const CLARITY_API_TOKEN = getConfigValue('clarity_api_token');
-
 // Endpoint URLs.
 export const API_BASE_URL = `https://clarity.microsoft.com/mcp`;
 export const SESSION_RECORDINGS_URL = `${API_BASE_URL}/recordings/sample`;
@@ -12,8 +8,10 @@ export const DOCUMENTATION_URL = `${API_BASE_URL}/documentation/query`;
 export const ANALYTICS_DASHBOARD_TOOL = "query-analytics-dashboard";
 export const DOCUMENTATION_TOOL = "query-documentation-resources";
 export const SESSION_RECORDINGS_TOOL = "list-session-recordings";
+export const LIST_ACCOUNTS_TOOL = "list-clarity-accounts";
 
 // Tool descriptions.
-export const ANALYTICS_DASHBOARD_DESCRIPTION = "Fetch Microsoft Clarity analytics data using a simplified natural language search query. The query should be focused on one specific data retrieval or aggregation task. Avoid complex multi-purpose queries. Time ranges should be explicitly specified when possible. If no time range is provided, prompt the user to specify one.";
+export const ANALYTICS_DASHBOARD_DESCRIPTION = "Fetch Microsoft Clarity analytics data using a simplified natural language search query. The query should be focused on one specific data retrieval or aggregation task. Avoid complex multi-purpose queries. Time ranges should be explicitly specified when possible. If no time range is provided, prompt the user to specify one. Use the 'account' parameter to specify which site/project to query (by domain name).";
 export const DOCUMENTATION_DESCRIPTION = "Retrieve Microsoft Clarity documentation snippets for finding answers to user questions including step-by-step screenshots for setup guides, features, usage, troubleshooting, and integration instructions. The query should be focused on one specific documentation topic or question. Avoid complex multi-purpose queries.";
-export const SESSION_RECORDINGS_DESCRIPTION = "List Microsoft Clarity session recordings based on specified filters. The filters allow you to narrow down the recordings by various criteria such as URLs, device types, browser, OS, country, city, and more. The date filter is required and must be in UTC ISO 8601 format.";
+export const SESSION_RECORDINGS_DESCRIPTION = "List Microsoft Clarity session recordings based on specified filters. The filters allow you to narrow down the recordings by various criteria such as URLs, device types, browser, OS, country, city, and more. The date filter is required and must be in UTC ISO 8601 format. Use the 'account' parameter to specify which site/project to query (by domain name).";
+export const LIST_ACCOUNTS_DESCRIPTION = "List all configured Microsoft Clarity accounts/projects available for querying. Returns domain names that can be passed as the 'account' parameter to other tools. Shows which account is the default.";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,16 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
 
 import pkg from "../package.json" with { type: "json" };
 
 import {
   ANALYTICS_DASHBOARD_DESCRIPTION,
   ANALYTICS_DASHBOARD_TOOL,
-  CLARITY_API_TOKEN,
   DOCUMENTATION_DESCRIPTION,
   DOCUMENTATION_TOOL,
+  LIST_ACCOUNTS_DESCRIPTION,
+  LIST_ACCOUNTS_TOOL,
   SESSION_RECORDINGS_DESCRIPTION,
   SESSION_RECORDINGS_TOOL
 } from "./constants.js";
@@ -16,6 +18,7 @@ import {
   SYSTEM_INSTRUCTIONS_PROMPT
 } from "./instructions.js";
 import {
+  listConfiguredAccounts,
   listSessionRecordingsAsync,
   queryAnalyticsDashboardAsync,
   queryDocumentationAsync
@@ -24,53 +27,79 @@ import {
   ListRequest,
   SearchRequest,
 } from "./types.js";
+import { loadAccounts } from "./accounts.js";
+
+// Account parameter — added to data-fetching tools
+const AccountParam = z.string().optional().describe(
+  "The domain name of the Clarity project/account to query (e.g., 'crowntrophy.com', 'zenworkflow.app'). " +
+  "Use the list-clarity-accounts tool to see available accounts. " +
+  "If omitted, the default account is used."
+);
 
 // Create server instance
 const server = new McpServer(
   {
     name: pkg.name,
     version: pkg.version,
-    capabilities: {
-      resources: {},
-      tools: {}
-    },
+  
   },
   {
     instructions: SYSTEM_INSTRUCTIONS_PROMPT,
   }
 );
 
-// Register the query-analytics-data tool
+// Register the list-accounts tool
 server.tool(
-  ANALYTICS_DASHBOARD_TOOL,             /* Name */
-  ANALYTICS_DASHBOARD_DESCRIPTION,      /* Description */
-  SearchRequest,                        /* Parameter Schema */
-  {                                     /* Metadata & Annotations */
+  LIST_ACCOUNTS_TOOL,
+  LIST_ACCOUNTS_DESCRIPTION,
+  {},
+  {
+    title: "List Clarity Accounts",
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: false
+  },
+  async () => {
+    return listConfiguredAccounts();
+  }
+);
+
+// Register the query-analytics-dashboard tool
+server.tool(
+  ANALYTICS_DASHBOARD_TOOL,
+  ANALYTICS_DASHBOARD_DESCRIPTION,
+  {
+    ...SearchRequest,
+    account: AccountParam,
+  },
+  {
     title: "Query Analytics Dashboard",
     readOnlyHint: true,
     destructiveHint: false,
     openWorldHint: false
   },
-  async ({ query }) => {
-    return await queryAnalyticsDashboardAsync(query, Intl.DateTimeFormat().resolvedOptions().timeZone);
+  async ({ query, account }) => {
+    return await queryAnalyticsDashboardAsync(query, Intl.DateTimeFormat().resolvedOptions().timeZone, account);
   }
 );
 
 // Register the session-recordings tool
 server.tool(
-  SESSION_RECORDINGS_TOOL,              /* Name */
-  SESSION_RECORDINGS_DESCRIPTION,       /* Description */
-  ListRequest,                          /* Parameter Schema */
-  {                                     /* Metadata & Annotations */
+  SESSION_RECORDINGS_TOOL,
+  SESSION_RECORDINGS_DESCRIPTION,
+  {
+    ...ListRequest,
+    account: AccountParam,
+  },
+  {
     title: "List Session Recordings",
     readOnlyHint: true,
     destructiveHint: false,
     openWorldHint: false
   },
-  async ({ filters, sortBy, count }) => {
+  async ({ filters, sortBy, count, account }) => {
     const now = new Date().toISOString();
 
-    // Calculate end as now, start as now - numOfDays
     const endDate = new Date(filters?.date?.end || now);
     const startDate = new Date(filters?.date?.start || now);
 
@@ -78,16 +107,16 @@ server.tool(
       startDate.setDate(endDate.getDate() - 2);
     }
 
-    return await listSessionRecordingsAsync(startDate, endDate, filters, sortBy, count);
+    return await listSessionRecordingsAsync(startDate, endDate, filters, sortBy, count, account);
   }
 );
 
 // Register the query-documentation-resources tool
 server.tool(
-  DOCUMENTATION_TOOL,                   /* Name */
-  DOCUMENTATION_DESCRIPTION,            /* Description */
-  SearchRequest,                        /* Parameter Schema */
-  {                                     /* Metadata & Annotations */
+  DOCUMENTATION_TOOL,
+  DOCUMENTATION_DESCRIPTION,
+  SearchRequest,
+  {
     title: "Query Documentation Resources",
     readOnlyHint: true,
     destructiveHint: false,
@@ -100,17 +129,22 @@ server.tool(
 
 // Main function
 async function main() {
-  // Log configuration status
-  if (CLARITY_API_TOKEN) {
-    console.error("Clarity API token configured via environment/command-line");
+  const config = loadAccounts();
+  const accountCount = Object.keys(config.accounts).length;
+
+  if (accountCount > 0) {
+    console.error(`Loaded ${accountCount} Clarity account(s): ${Object.keys(config.accounts).join(", ")}`);
+    if (config.default) {
+      console.error(`Default account: ${config.default}`);
+    }
   } else {
-    console.error("No Clarity API token configured, it must be provided with each request");
+    console.error("No Clarity accounts configured. Use ~/.clarity-mcp/accounts.json or --clarity_api_token");
   }
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
 
-  console.error("Microsoft Clarity Data Export MCP Server running on stdio...");
+  console.error("Clarity MCP Server (multi-account) running on stdio...");
 }
 
 // Run the server

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -1,18 +1,30 @@
 import {
   ANALYTICS_DASHBOARD_TOOL,
   DOCUMENTATION_TOOL,
+  LIST_ACCOUNTS_TOOL,
   SESSION_RECORDINGS_TOOL
 } from "./constants.js";
 
 export const SYSTEM_INSTRUCTIONS_PROMPT = `
 This MCP server provides access to Microsoft Clarity analytics dashboard data, documentation resources and session recordings.
+It supports multiple Clarity projects/accounts — each identified by domain name.
+
+## Multi-Account Usage
+
+Use \`${LIST_ACCOUNTS_TOOL}\` to see all configured projects.
+Pass the \`account\` parameter (domain name) to any data tool to specify which project to query.
+If only one account is configured, or a default is set, it will be used automatically.
 
 ## Available Tools
 
-### 1. Session Recordings Tool: \`${SESSION_RECORDINGS_TOOL}\`
+### 1. List Accounts Tool: \`${LIST_ACCOUNTS_TOOL}\`
+Lists all configured Clarity accounts/projects. Use this first to discover available domains.
+
+### 2. Session Recordings Tool: \`${SESSION_RECORDINGS_TOOL}\`
 Lists Microsoft Clarity session recordings with metadata including session links, duration, and user interaction timelines.
 
 **Parameters:**
+- account: Domain name of the Clarity project (e.g., "crowntrophy.com")
 - filters: Optional filters for sessions (date range, device type, etc.)
 - sortBy: Sort option using SortOptions enum (default: SessionStart_DESC)
 - count: Number of sessions to retrieve (1-250, default: 100)
@@ -28,13 +40,10 @@ Lists Microsoft Clarity session recordings with metadata including session links
 - PageCount_DESC (most pages first)
 
 **Example Usage:**
-- Get 10 newest sessions: { "count": 10, "sortBy": "SessionStart_DESC" }
-- Get 20 longest sessions from date range: { "filters": { "date": { "start": "2024-01-01T00:00:00.000Z", "end": "2024-01-31T23:59:59.999Z" } }, "sortBy": "SessionDuration_DESC", "count": 20 }
-- Get 15 mobile sessions with most clicks: { "filters": { "deviceType": ["Mobile"] }, "sortBy": "SessionClickCount_DESC", "count": 15 }
-- Get oldest sessions first: { "sortBy": "SessionStart_ASC", "count": 100 }
-- Get sessions with most page views: { "sortBy": "PageCount_DESC", "count": 100 }
+- Get 10 newest sessions: { "account": "example.com", "count": 10, "sortBy": "SessionStart_DESC" }
+- Get 20 longest sessions from date range: { "account": "example.com", "filters": { "date": { "start": "2024-01-01T00:00:00.000Z", "end": "2024-01-31T23:59:59.999Z" } }, "sortBy": "SessionDuration_DESC", "count": 20 }
 
-### 2. Analytics Dashboard Tool: \`${ANALYTICS_DASHBOARD_TOOL}\`
+### 3. Analytics Dashboard Tool: \`${ANALYTICS_DASHBOARD_TOOL}\`
 This tool is your **primary and authoritative data source** for all dashboard-related insights and must be used to retrieve accurate, real-time data from the Microsoft Clarity dashboard.
 
 #### Capabilities & Output
@@ -48,124 +57,28 @@ Microsoft Clarity dashboard provides comprehensive insights into the behavior an
 - **Performance Indicators**: Core Web Vitals (largest contentful paint, first input delay, cumulative layout shift)
 - **User Experience**: Quick backs, dead clicks, rage clicks, session duration
 
-The dashboard helps website owners understand their audience, traffic sources, content preferences, user engagement patterns, and identify potential technical issues.
-
 **IMPORTANT GUIDELINES:**
 - Use SIMPLE, SINGLE-PURPOSE queries only
 - Always specify time ranges, full URLs and parameters explicitly; prompt the user if not provided
+- Always include the \`account\` parameter to specify which site to query
 - Break complex requests into multiple separate queries
 - Focus on ONE trend or aggregated metric per query
 
 **Good Examples:**
-- "Page views count for the last 7 days"
+- "Page views count for the last 7 days" (with account: "mysite.com")
 - "Top javascript errors for PC in January 2024"
 - "Top pages for mobile in the last 3 days"
-- "Distinct users visited https://www.example.com page last month?"
-- "Average session duration for desktop users this week?"
 
 **Bad Examples (DON'T DO THIS):**
-- "Show me page views, average session duration, and conversion data for all devices across multiple pages with user demographics" (too complex, multiple purposes)
+- "Show me page views, average session duration, and conversion data for all devices across multiple pages" (too complex)
 - "Analyze user behavior" (too vague, no time range)
-- "Get all metrics" (too broad)
 
-**Best Practices:**
-✅ Be specific about time ranges
-✅ Focus on one metric per query
-✅ Specify device type, page, or user segment when relevant
-✅ Use clear, actionable language
-
-❌ Don't combine multiple unrelated metrics
-❌ Don't use vague or overly broad queries
-❌ Don't omit time ranges
-❌ Don't ask for "everything" or "all data"
-
-### 3. Documentation Tool: \`${DOCUMENTATION_TOOL}\`
+### 4. Documentation Tool: \`${DOCUMENTATION_TOOL}\`
 
 This tool is your **primary and authoritative data source** for all documentation-related questions and must be used to retrieve accurate, real-time data from the Microsoft Clarity documentation.
+Documentation queries do not require an account parameter — they are global.
 
 #### Capabilities & Output
 
-Microsoft Clarity documentation provides comprehensive, authoritative answers to every aspect of Clarity including step-by-step screenshots for setup guides, features, usage, troubleshooting, and integration instructions. The tool covers all topics and headlines from the official documentation, including:
-
-- **Getting Started & Installation**
-	- About Clarity
-	- Sign up for Clarity
-	- Setup and install Clarity code
-	- Verify your installation
-	- Setup via third-party platforms (WordPress, Wix, Shopify, etc.)
-	- Setup for Vibe Coding Platforms
-	- Privacy disclosure wording
-	- Data retention
-	- Cookies and consent management (including Consent Mode)
-	- troubleshooting installation
-
-- **Clarity for Mobile Apps**
-	- Android SDK
-	- iOS SDK
-	- React Native SDK
-	- Flutter SDK
-	- Cordova and Ionic SDK
-
-- **Dashboard & Insights**
-	- Insights overview
-	- Dashboard features
-	- E-commerce features
-	- Blog features
-	- Recipe features
-
-- **Session Recordings**
-	- What is a session recording?
-	- Session list
-	- Inline player
-	- Live recordings
-	- Visitor profile
-
-- **Heatmaps**
-	- What is a heatmap?
-	- Heatmap features
-	- Click maps
-	- Scroll maps
-	- Area maps
-
-- **Filters & Segments**
-	- Filters overview
-	- Exclusion filters
-	- Segments
-	- Regular expressions
-
-- **Settings & Management**
-	- Account management
-	- Team management
-	- Masking
-	- IP blocking
-	- Funnels
-	- Smart events
-
-- **Copilot in Clarity**
-	- Copilot overview
-	- Copilot chat
-	- Session insights
-	- Grouped session insights
-	- Heatmaps insights
-
-- **Reference**
-	- API Reference
-	- Identify API
-	- Export API
-	- Custom tags
-	- Troubleshooting (installation, settings, recordings, heatmaps, dashboard, live extension)
-	- FAQ
-	- Glossary of terms
-	- Share Clarity
-	- Download Clarity
-
-- **Additional Links & Resources**
-	- Blog
-	- Case studies
-	- Demo
-	- Previous versions
-	- Contribute
-	- Privacy, Terms of Use, Trademarks
-
-The documentation plugin helps users answer frequently asked questions for every headline and topic listed in the official Microsoft Clarity documentation, supporting all use cases, troubleshooting, integrations, and advanced features.
+Microsoft Clarity documentation provides comprehensive, authoritative answers to every aspect of Clarity including step-by-step screenshots for setup guides, features, usage, troubleshooting, and integration instructions.
 `;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,6 +1,5 @@
 import {
   ANALYTICS_DASHBOARD_URL,
-  CLARITY_API_TOKEN,
   DOCUMENTATION_URL,
   SESSION_RECORDINGS_URL
 } from "./constants.js";
@@ -10,30 +9,88 @@ import {
   SortOptionsEnum
 } from "./types.js";
 import { tryAsync } from "./utils.js";
+import { resolveToken, listAccounts, getDefaultAccount } from "./accounts.js";
+
+function resolveTokenOrError(account?: string): { token: string; account: string } {
+  const resolved = resolveToken(account);
+  if (resolved) return resolved;
+
+  const accounts = listAccounts();
+  if (accounts.length === 0) {
+    throw new Error(
+      "No Clarity accounts configured. Create ~/.clarity-mcp/accounts.json or pass --clarity_api_token."
+    );
+  }
+
+  if (!account) {
+    throw new Error(
+      `Multiple accounts configured but no account specified and no default set. ` +
+      `Available accounts: ${accounts.join(", ")}. ` +
+      `Specify one with the 'account' parameter or set "default" in accounts.json.`
+    );
+  }
+
+  throw new Error(
+    `Account "${account}" not found. Available accounts: ${accounts.join(", ")}`
+  );
+}
 
 export async function queryAnalyticsDashboardAsync(
   query: string,
   timezone: string,
+  account?: string,
 ): Promise<any> {
-  return await tryAsync(ANALYTICS_DASHBOARD_URL, {
+  const { token, account: resolvedAccount } = resolveTokenOrError(account);
+
+  const result = await tryAsync(ANALYTICS_DASHBOARD_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      ...(CLARITY_API_TOKEN ? { 'Authorization': `Bearer ${CLARITY_API_TOKEN}` } : {}),
+      'Authorization': `Bearer ${token}`,
     },
     body: JSON.stringify({
       query: query,
       timezone: timezone,
     })
   });
+
+  // Tag the response with which account was used
+  if (result?.content?.[0]?.type === "text") {
+    try {
+      const data = JSON.parse(result.content[0].text);
+      result.content[0].text = JSON.stringify({ _account: resolvedAccount, ...data }, null, 2);
+    } catch { /* leave as-is if not valid JSON */ }
+  }
+
+  return result;
 }
 
 export async function queryDocumentationAsync(query: string): Promise<any> {
+  // Documentation doesn't need an account - it's global
+  // But we still need a valid token to authenticate
+  const accounts = listAccounts();
+  let token: string | undefined;
+
+  if (accounts.length > 0) {
+    const defaultAcct = getDefaultAccount();
+    const resolved = resolveToken(defaultAcct || accounts[0]);
+    token = resolved?.token;
+  }
+
+  if (!token) {
+    return {
+      content: [{
+        type: "text",
+        text: "No Clarity API token available. Configure at least one account.",
+      }],
+    };
+  }
+
   return await tryAsync(DOCUMENTATION_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      ...(CLARITY_API_TOKEN ? { 'Authorization': `Bearer ${CLARITY_API_TOKEN}` } : {})
+      'Authorization': `Bearer ${token}`,
     },
     body: JSON.stringify({
       query: query,
@@ -46,13 +103,16 @@ export async function listSessionRecordingsAsync(
   endDate: Date,
   filters: FiltersType,
   sortBy: SortOptionsType,
-  count: number
+  count: number,
+  account?: string,
 ): Promise<any> {
-  return await tryAsync(SESSION_RECORDINGS_URL, {
+  const { token, account: resolvedAccount } = resolveTokenOrError(account);
+
+  const result = await tryAsync(SESSION_RECORDINGS_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      ...(CLARITY_API_TOKEN ? { 'Authorization': `Bearer ${CLARITY_API_TOKEN}` } : {})
+      'Authorization': `Bearer ${token}`,
     },
     body: JSON.stringify({
       sortBy: SortOptionsEnum[sortBy],
@@ -62,4 +122,47 @@ export async function listSessionRecordingsAsync(
       count: count
     })
   });
+
+  // Tag the response
+  if (result?.content?.[0]?.type === "text") {
+    try {
+      const data = JSON.parse(result.content[0].text);
+      result.content[0].text = JSON.stringify({ _account: resolvedAccount, ...data }, null, 2);
+    } catch { /* leave as-is */ }
+  }
+
+  return result;
+}
+
+export function listConfiguredAccounts(): any {
+  const accounts = listAccounts();
+  const defaultAccount = getDefaultAccount();
+
+  if (accounts.length === 0) {
+    return {
+      content: [{
+        type: "text",
+        text: "No Clarity accounts configured. Create ~/.clarity-mcp/accounts.json with your project domains and API tokens.",
+      }],
+    };
+  }
+
+  const accountList = accounts.map(domain => ({
+    domain,
+    isDefault: domain === defaultAccount,
+  }));
+
+  return {
+    content: [{
+      type: "text",
+      text: JSON.stringify({
+        accounts: accountList,
+        total: accounts.length,
+        default: defaultAccount || null,
+        configHelp: accounts.length === 1 && !defaultAccount
+          ? "Single account configured — it will be used automatically."
+          : undefined,
+      }, null, 2),
+    }],
+  };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,13 +1,11 @@
-import { CLARITY_API_TOKEN } from "./constants.js";
-
 // Get configuration from environment variables or command-line arguments
 export const getConfigValue = (name: string, fallback?: string): string | undefined => {
   // Check command line args first (format: --name=value or --name value)
   const argIndex = process.argv.findIndex((arg) => arg.startsWith(`--${name}`));
   if (argIndex !== -1) {
-    const arg = process.argv[argIndex];
+    const arg = process.argv[argIndex]!;
     if (arg.includes("=")) {
-      return arg.split("=")[1];
+      return arg.split("=")[1]!;
     }
     // --name value format: return next argument if it exists and isn't another flag
     const nextArgIndex = argIndex + 1;
@@ -28,19 +26,6 @@ export const getConfigValue = (name: string, fallback?: string): string | undefi
 };
 
 export const tryAsync = async (input: string | URL | Request, init?: RequestInit | undefined): Promise<any> => {
-  // Use provided token or fallback to environment/command-line variables
-  // Check if we have the necessary credentials
-  if (!CLARITY_API_TOKEN) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: "No Clarity API token provided. Please provide a token via the 'token' parameter, CLARITY_API_TOKEN environment variable, or --clarity_api_token command-line argument.",
-        },
-      ],
-    };
-  }
-
   try {
     const response = await fetch(input, init);
 
@@ -64,7 +49,7 @@ export const tryAsync = async (input: string | URL | Request, init?: RequestInit
       content: [
         {
           type: "text",
-          text: "An error occurred while fetching the data.",
+          text: `An error occurred while fetching the data: ${error instanceof Error ? error.message : String(error)}`,
         },
       ],
     };


### PR DESCRIPTION
## Summary

Adds multi-account support so a single MCP server instance can query multiple Clarity projects, identified by domain name.

### The Problem

The current server supports one API token at a time. Anyone managing multiple sites with Clarity (agencies, consultants, multi-property teams) has to either:
- Run separate server instances per project
- Swap tokens manually between queries

### The Solution

A `~/.clarity-mcp/accounts.json` config file that maps domain names to API tokens:

```json
{
  "default": "mysite.com",
  "accounts": {
    "mysite.com": { "token": "token-1" },
    "clientsite.com": { "token": "token-2" },
    "blog.example.org": { "token": "token-3" }
  }
}
```

Domain names are natural identifiers — easy to remember, no ambiguity. Users just say *"show me sessions for clientsite.com"* and it works.

### Changes

- **New `src/accounts.ts`** — config loading, token resolution, account listing
- **New `list-clarity-accounts` tool** — lets the LLM discover available projects  
- **`account` parameter** added to `query-analytics-dashboard` and `list-session-recordings` tools
- **Response tagging** — each response includes which account was queried (`_account` field)
- **Updated instructions** — reflects multi-account usage patterns
- **Removed `CLARITY_API_TOKEN` from `utils.ts`** — token resolution moved to accounts module

### Backward Compatible

- Single `--clarity_api_token` CLI arg or `CLARITY_API_TOKEN` env var still works (becomes a "default" account)
- If only one account is configured, it auto-selects without requiring the `account` parameter
- Documentation tool works without account specification (uses any available token)

### Config File Locations (checked in order)

1. `--accounts-file=/custom/path.json`  
2. `~/.clarity-mcp/accounts.json`
3. `~/.config/clarity-mcp/accounts.json`

### Context

I've been using Clarity since before public release and install it on every client site by default. Managing 15+ properties with per-project tokens was the friction that prompted this. The domain-keyed approach means zero mental overhead — you already know your sites by their domains.

Happy to iterate on the implementation if the team has preferences on config format or API conventions.